### PR TITLE
fixed root cause of the IDP memory leak. 

### DIFF
--- a/src/nfv9.c
+++ b/src/nfv9.c
@@ -518,6 +518,9 @@ void nfv9_process_flow_record (struct flow_record *nf_record,
                 flow_data += htons(cur_template->fields[i].FieldLength);
                 break;
             case IDP: 
+                if (nf_record->idp != NULL) {
+                    free(nf_record->idp);
+                }
                 nf_record->idp_len = htons(cur_template->fields[i].FieldLength);
                 nf_record->idp = malloc(nf_record->idp_len);
                 if (nf_record->idp != NULL) {
@@ -542,13 +545,6 @@ void nfv9_process_flow_record (struct flow_record *nf_record,
 
                 /* Update all enabled feature modules */
                 update_all_features(feature_list);
-
-                /* free up the IDP packet data */
-                if (nf_record->idp != NULL) {
-                    free(nf_record->idp);
-                    nf_record->idp = NULL;
-                    nf_record->idp_len = 0;
-                }
                 flow_data += htons(cur_template->fields[i].FieldLength);
                 break;
             case SPLT:

--- a/src/pkt_proc.c
+++ b/src/pkt_proc.c
@@ -408,7 +408,7 @@ static enum status process_nfv9 (const struct pcap_pkthdr *h, const void *start,
 	                  nfv9_flow_key_init(&key, cur_template, flow_data);
 
 	                  // get a nf record
-	                  struct flow_record *nf_record;
+	                  struct flow_record *nf_record = NULL;
 	                  nf_record = flow_key_get_record(&key, CREATE_RECORDS); 
     
 	                  // fill out record
@@ -920,6 +920,9 @@ void process_packet (unsigned char *ignore, const struct pcap_pkthdr *header,
      * is the first packet in the flow with nonzero data payload
      */
     if ((report_idp) && record->op && (record->idp_len == 0)) {
+        if (record->idp != NULL) {
+            free(record->idp);
+        }
         record->idp_len = (ntohs(ip->ip_len) < report_idp ? ntohs(ip->ip_len) : report_idp);
         record->idp = malloc(record->idp_len);
         memcpy(record->idp, ip, record->idp_len);


### PR DESCRIPTION
It was doubling allocaing the IDP in malformed packets due to the process flow.